### PR TITLE
Move reservation action to header with employee display

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ let kamerPrijzen = JSON.parse(localStorage.getItem('kamerPrijzen')) || {
 };
 let currentRes = null;
 let currentHotel = null;
+let medewerkerNaam = localStorage.getItem('medewerkerNaam') || '';
 
 window.addEventListener('DOMContentLoaded', () => {
   currentHotel = 'beach';
@@ -20,6 +21,7 @@ window.addEventListener('DOMContentLoaded', () => {
   if (currentHotel === 'beach') name.textContent = 'Beach Resort';
   // locatie-keuze verwijderd
   document.getElementById('systeem').classList.remove('hidden');
+  document.getElementById('employeeNameDisplay').textContent = medewerkerNaam || 'Naam medewerker';
 });
 
 document.getElementById('newResBtn').addEventListener('click', () => {
@@ -124,6 +126,7 @@ document.getElementById('adminBtn').addEventListener('click', () => {
       <td><input type="text" id="beschrijving_${type}" value="${kamerPrijzen[type].beschrijving}"></td>`;
     table.appendChild(row);
   });
+  document.getElementById('adminUserName').value = medewerkerNaam;
   document.getElementById('adminModal').classList.remove('hidden');
 });
 
@@ -133,6 +136,9 @@ document.getElementById('saveAdmin').addEventListener('click', () => {
     kamerPrijzen[type].beschrijving = document.getElementById(`beschrijving_${type}`).value;
   });
   localStorage.setItem('kamerPrijzen', JSON.stringify(kamerPrijzen));
+  medewerkerNaam = document.getElementById('adminUserName').value.trim();
+  localStorage.setItem('medewerkerNaam', medewerkerNaam);
+  document.getElementById('employeeNameDisplay').textContent = medewerkerNaam || 'Naam medewerker';
   document.getElementById('adminModal').classList.add('hidden');
 });
 

--- a/index.html
+++ b/index.html
@@ -11,8 +11,14 @@
 </head>
 <body>
   <header id="hotelHeader">
-    <img id="hotelLogo" src="logos/logo_beach.png" alt="Hotel Logo">
-    <h1 id="hotelName">Beach Resort</h1>
+    <div class="header-left">
+      <img id="hotelLogo" src="logos/logo_beach.png" alt="Hotel Logo">
+      <h1 id="hotelName">Beach Resort</h1>
+    </div>
+    <div class="header-right">
+      <button type="button" id="newResBtn"><span class="material-icons">add</span></button>
+      <div id="userInfo"><span class="material-icons">person</span><span id="employeeNameDisplay">Naam medewerker</span></div>
+    </div>
   </header>
 
   <main id="app">
@@ -22,7 +28,6 @@
       <div class="columns">
         <div class="left-col">
           <h2>Menu</h2>
-          <button type="button" id="newResBtn"><span class="material-icons">add</span> Nieuwe reservering</button>
           <form id="zoekForm">
             <label>Reserveringsnummer of naam:<br>
               <input type="text" id="zoekTerm">
@@ -88,6 +93,7 @@
   <div id="adminModal" class="modal hidden">
     <div class="modal-content">
       <h3>Administratie - Kamerprijzen en Beschrijvingen</h3>
+      <label>Medewerkernaam:<br><input type="text" id="adminUserName"></label>
       <table id="adminTable"></table>
       <button id="saveAdmin"><span class="material-icons">save</span> Opslaan</button>
       <hr><button id="exportDataBtn"><span class="material-icons">save_alt</span> Gegevens opslaan (Export)</button><input type="file" id="importDataInput" accept=".json" style="display:none"><button id="importDataBtn"><span class="material-icons">folder_open</span> Gegevens laden (Import)</button><button id="closeAdmin"><span class="material-icons">close</span> Sluiten</button>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,10 @@
 body { font-family: Arial, sans-serif; margin:0; padding:0; }
-header { display:flex; align-items:center; padding:1em; color:white; }
+header { display:flex; align-items:center; justify-content:space-between; padding:1em; color:white; }
 header img { height:50px; margin-right:1em; }
+.header-left { display:flex; align-items:center; }
+.header-right { display:flex; align-items:center; gap:1em; }
+.header-right button { width:auto; }
+#userInfo { display:flex; align-items:center; gap:0.3em; }
 .columns { display:flex; gap:1em; padding:1em; }
 .left-col, .right-col { flex:1; background:#f9f9f9; padding:1em; border-radius:4px; }
 .menu-nav { margin-top:2em; display:flex; flex-direction:column; gap:0.5em; }


### PR DESCRIPTION
## Summary
- Move "Nieuwe reservering" button to header and replace text with a plus icon
- Add employee name placeholder with Material icon and load name from admin settings
- Extend administration modal to save employee name and update header

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893b7d19e14832c9159180c3acb9312