### PR TITLE
Add randomizers and discount code support

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,8 +44,8 @@
             <div id="detailView">
               <h2>Reserveringsgegevens</h2>
               <form id="detailsForm" class="hidden">
-            <div id="resNumDisplay"></div>
-            <label>Naam:<br><input type="text" id="naam"></label>
+              <div id="resNumDisplay"></div>
+              <label>Naam:<br><input type="text" id="naam"><button type="button" id="randomNaamBtn"><span class="material-icons">shuffle</span></button></label>
             <label>Aantal gasten:<br><input type="number" id="gasten" min="1" max="6"></label>
             <label>Aantal nachten:<br><input type="number" id="nachten" min="1" max="30"></label>
             <label>Kamernummer:<br><input type="text" id="kamerpas"></label>
@@ -56,8 +56,9 @@
             </label>
             <label>Etage:<br><input type="number" id="etage" min="1" max="20"></label>
             <label>Aankomst:<br><input type="date" id="aankomst"></label>
-            <label>Paspoort/ID nummer:<br><input type="text" id="idNummer" placeholder="NL1234567"></label>
-            <label>Creditcard nummer:<br><input type="text" id="ccNummer" placeholder="1234 5678 9012 3456"></label>
+              <label>Paspoort/ID nummer:<br><input type="text" id="idNummer" placeholder="NL1234567"><button type="button" id="randomIdBtn"><span class="material-icons">shuffle</span></button></label>
+              <label>Creditcard nummer:<br><input type="text" id="ccNummer" placeholder="1234 5678 9012 3456"><button type="button" id="randomCcBtn"><span class="material-icons">shuffle</span></button></label>
+              <label>Kortingscode:<br><input type="text" id="kortingscode"></label>
             <p>Status: <span id="status"></span></p>
             <div id="bedragDisplay"></div>
             <div class="buttons">
@@ -95,6 +96,9 @@
       <h3>Administratie - Kamerprijzen en Beschrijvingen</h3>
       <label>Medewerkernaam:<br><input type="text" id="adminUserName"></label>
       <table id="adminTable"></table>
+      <h4>Kortingscodes</h4>
+      <table id="discountTable"></table>
+      <button type="button" id="addDiscountBtn"><span class="material-icons">add</span> Kortingscode toevoegen</button>
       <button id="saveAdmin"><span class="material-icons">save</span> Opslaan</button>
       <hr><button id="exportDataBtn"><span class="material-icons">save_alt</span> Gegevens opslaan (Export)</button><input type="file" id="importDataInput" accept=".json" style="display:none"><button id="importDataBtn"><span class="material-icons">folder_open</span> Gegevens laden (Import)</button><button id="closeAdmin"><span class="material-icons">close</span> Sluiten</button>
     </div>


### PR DESCRIPTION
## Summary
- Add randomizer buttons for name, passport/ID, and credit card fields plus a new discount code field.
- Introduce discount code management in administration modal with amount field and add/remove controls.
- Apply discount codes to reservation totals and include them in export/import data.

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893c0cf7594832c856df343fc6d371a