### PR TITLE
Voeg extra's veld toe en verbeter UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,6 @@
           </form>
           <nav class="menu-nav">
             <button type="button" id="overviewBtn"><span class="material-icons">list</span> Overzicht reserveringen</button>
-            <button type="button" id="adminBtn"><span class="material-icons">settings</span> Administratie</button>
           </nav>
         </div>
         <div class="right-col">
@@ -45,22 +44,24 @@
               <h2>Reserveringsgegevens</h2>
               <form id="detailsForm" class="hidden">
               <div id="resNumDisplay"></div>
-              <label>Naam:<br><input type="text" id="naam"><button type="button" id="randomNaamBtn"><span class="material-icons">shuffle</span></button></label>
+              <label class="with-rand">Naam:<br><input type="text" id="naam"><button type="button" id="randomNaamBtn" class="random-btn"><span class="material-icons">shuffle</span></button></label>
             <label>Aantal gasten:<br><input type="number" id="gasten" min="1" max="6"></label>
             <label>Aantal nachten:<br><input type="number" id="nachten" min="1" max="30"></label>
             <label>Kamernummer:<br><input type="text" id="kamerpas"></label>
-            <label>Type kamer:<br>
+            <label class="kamer-type">Type kamer:<br>
               <input type="text" id="kamer" readonly>
               <button type="button" id="selectKamerBtn"><span class="material-icons">search</span> Selecteren</button>
               <button type="button" id="upgradeBtn"><span class="material-icons">upgrade</span> Upgrade</button>
             </label>
             <label>Etage:<br><input type="number" id="etage" min="1" max="20"></label>
             <label>Aankomst:<br><input type="date" id="aankomst"></label>
-              <label>Paspoort/ID nummer:<br><input type="text" id="idNummer" placeholder="NL1234567"><button type="button" id="randomIdBtn"><span class="material-icons">shuffle</span></button></label>
-              <label>Creditcard nummer:<br><input type="text" id="ccNummer" placeholder="1234 5678 9012 3456"><button type="button" id="randomCcBtn"><span class="material-icons">shuffle</span></button></label>
+              <label class="with-rand">Paspoort/ID nummer:<br><input type="text" id="idNummer" placeholder="NL1234567"><button type="button" id="randomIdBtn" class="random-btn"><span class="material-icons">shuffle</span></button></label>
+              <label class="with-rand">Creditcard nummer:<br><input type="text" id="ccNummer" placeholder="1234 5678 9012 3456"><button type="button" id="randomCcBtn" class="random-btn"><span class="material-icons">shuffle</span></button></label>
               <label>Kortingscode:<br><input type="text" id="kortingscode"></label>
             <p>Status: <span id="status"></span></p>
             <div id="bedragDisplay"></div>
+            <label>Extra’s:<br><input type="number" id="extraBedrag" min="0" step="0.01"></label>
+            <div id="totaalDisplay"></div>
             <div class="buttons">
               <button type="button" id="checkinBtn"><span class="material-icons">login</span> Inchecken</button>
               <button type="button" id="checkoutBtn"><span class="material-icons">logout</span> Uitchecken</button>

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ header img { height:50px; margin-right:1em; }
 .header-left { display:flex; align-items:center; }
 .header-right { display:flex; align-items:center; gap:1em; }
 .header-right button { width:auto; }
-#userInfo { display:flex; align-items:center; gap:0.3em; }
+#userInfo { display:flex; align-items:center; gap:0.3em; cursor:pointer; }
 .columns { display:flex; gap:1em; padding:1em; }
 .left-col, .right-col { flex:1; background:#f9f9f9; padding:1em; border-radius:4px; }
 .menu-nav { margin-top:2em; display:flex; flex-direction:column; gap:0.5em; }
@@ -66,3 +66,18 @@ input.placeholder-active {
 
 /* Bedrag kader */
 #bedragDisplay { background: #fffae6; padding: 0.5em; margin-top: 0.5em; border: 2px solid #ffd700; font-weight: bold; }
+
+/* Randomizer buttons inline */
+label.with-rand input { width: calc(100% - 50px); display:inline-block; }
+label.with-rand button { width:40px; margin-left:4px; background:#ffeb3b; color:black; display:inline-flex; }
+
+/* Kamer type buttons inline */
+label.kamer-type input { width: calc(100% - 110px); display:inline-block; }
+label.kamer-type button { width:auto; margin-left:4px; display:inline-flex; }
+
+/* Action buttons in one row */
+.buttons { display:flex; gap:0.5em; }
+.buttons button { width:auto; flex:1; }
+
+/* Kamerselectie tabel spacing */
+#kamerSelectTable td { padding:0.8em 0.5em; }


### PR DESCRIPTION
## Samenvatting
- Randomizerknoppen naast invulvelden geplaatst en geel gemaakt; type kamer- en actieknoppen staan nu horizontaal.
- Administratieknop verwijderd; gebruikersnaam in de header opent nu de administratie.
- Extra's veld en totaalbedrag toegevoegd en overzichten uitgebreid met bedrag, extra's en totaal.

## Testinstructies
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6893c5ca5518832ca2d1cd86b7d025bf