### PR TITLE
Add header search field and calculator

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,21 +76,60 @@ document.getElementById('newResBtn').addEventListener('click', () => {
   document.getElementById('detailView').classList.remove('hidden');
 });
 
-document.getElementById('zoekForm').addEventListener('submit', (e) => {
-  e.preventDefault();
-  const term = document.getElementById('zoekTerm').value.trim();
-  if (!term) return;
-  let res = hotelData[term] || Object.values(hotelData).find(r => r.reserveringsnummer === term || r.naam.toLowerCase() === term.toLowerCase());
-  if (!res) {
-    res = generateReservation(term);
-    hotelData[term] = res;
-    saveData();
+const searchContainer = document.getElementById('searchContainer');
+const searchBtn = document.getElementById('searchBtn');
+const searchInput = document.getElementById('searchInput');
+
+function performSearch() {
+  const term = searchInput.value.trim();
+  if (!term) {
+    searchContainer.classList.remove('active');
+    return;
   }
-  currentRes = res;
-  fillDetails(res);
-  document.getElementById('detailsForm').classList.remove('hidden');
-  document.getElementById('overviewView').classList.add('hidden');
-  document.getElementById('detailView').classList.remove('hidden');
+  const res = hotelData[term] || Object.values(hotelData).find(r => r.reserveringsnummer === term || r.naam.toLowerCase() === term.toLowerCase());
+  if (res) {
+    currentRes = res;
+    fillDetails(res);
+    document.getElementById('detailsForm').classList.remove('hidden');
+    document.getElementById('overviewView').classList.add('hidden');
+    document.getElementById('detailView').classList.remove('hidden');
+  }
+  searchInput.value = '';
+  searchContainer.classList.remove('active');
+}
+
+searchBtn.addEventListener('click', () => {
+  if (!searchContainer.classList.contains('active')) {
+    searchContainer.classList.add('active');
+    searchInput.focus();
+  } else {
+    performSearch();
+  }
+});
+
+searchInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    performSearch();
+  }
+});
+
+const calcDisplay = document.getElementById('calcDisplay');
+document.querySelectorAll('.calc-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const val = btn.textContent;
+    if (val === 'C') {
+      calcDisplay.value = '';
+    } else if (val === '=') {
+      try {
+        calcDisplay.value = eval(calcDisplay.value) || '';
+      } catch {
+        calcDisplay.value = '';
+      }
+    } else {
+      calcDisplay.value += val;
+    }
+  });
 });
 
 document.getElementById('checkinBtn').addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -17,6 +17,10 @@
     </div>
     <div class="header-right">
       <button type="button" id="newResBtn"><span class="material-icons">add</span></button>
+      <div id="searchContainer">
+        <input type="text" id="searchInput" placeholder="Zoeken...">
+        <button type="button" id="searchBtn"><span class="material-icons">search</span></button>
+      </div>
       <div id="userInfo"><span class="material-icons">person</span><span id="employeeNameDisplay">Naam medewerker</span></div>
     </div>
   </header>
@@ -28,12 +32,27 @@
       <div class="columns">
         <div class="left-col">
           <h2>Menu</h2>
-          <form id="zoekForm">
-            <label>Reserveringsnummer of naam:<br>
-              <input type="text" id="zoekTerm">
-            </label>
-            <button type="submit"><span class="material-icons">search</span> Zoeken</button>
-          </form>
+          <div id="calculator">
+            <input type="text" id="calcDisplay" readonly>
+            <div class="calc-buttons">
+              <button class="calc-btn">7</button>
+              <button class="calc-btn">8</button>
+              <button class="calc-btn">9</button>
+              <button class="calc-btn">/</button>
+              <button class="calc-btn">4</button>
+              <button class="calc-btn">5</button>
+              <button class="calc-btn">6</button>
+              <button class="calc-btn">*</button>
+              <button class="calc-btn">1</button>
+              <button class="calc-btn">2</button>
+              <button class="calc-btn">3</button>
+              <button class="calc-btn">-</button>
+              <button class="calc-btn">0</button>
+              <button class="calc-btn">C</button>
+              <button class="calc-btn">=</button>
+              <button class="calc-btn">+</button>
+            </div>
+          </div>
           <nav class="menu-nav">
             <button type="button" id="overviewBtn"><span class="material-icons">list</span> Overzicht reserveringen</button>
           </nav>

--- a/style.css
+++ b/style.css
@@ -53,6 +53,68 @@ body.beach button:hover { background-color: #009e8a; }
   font-size: 2em;
 }
 
+/* Zoek knop in header */
+#searchContainer {
+  position: relative;
+  width: 60px;
+  height: 60px;
+}
+#searchBtn {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: white;
+  color: green;
+  padding: 0;
+}
+#searchBtn .material-icons {
+  color: green;
+  font-size: 2em;
+}
+#searchInput {
+  position: absolute;
+  right: 60px;
+  top: 0;
+  width: 0;
+  opacity: 0;
+  height: 60px;
+  border: none;
+  padding: 0;
+  border-radius: 30px 0 0 30px;
+  transition: width 0.3s, opacity 0.3s;
+}
+#searchContainer.active #searchInput {
+  width: 200px;
+  opacity: 1;
+  padding: 0 0.5em;
+  background: white;
+  border: 1px solid #757575;
+}
+#searchContainer.active #searchBtn {
+  border-radius: 0 30px 30px 0;
+}
+
+/* Rekenmachine */
+#calculator {
+  margin-top: 1em;
+}
+#calcDisplay {
+  width: 100%;
+  text-align: right;
+  padding: 0.4em;
+  border: 1px solid #757575;
+  border-radius: 4px;
+}
+.calc-buttons {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5em;
+  margin-top: 0.5em;
+}
+.calc-buttons button {
+  width: 100%;
+}
+
 /* Placeholder stijl */
 input.placeholder-active {
   color: #888;


### PR DESCRIPTION
## Summary
- Add expandable search icon to header that reveals input on click
- Search now only looks up existing reservations
- Provide simple calculator in left column for quick math

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689453f69d64832caee68d5d8ea071be