### PR TITLE
Introduce kamer type pills and stabilize header layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,6 +51,37 @@ document.getElementById('randomCcBtn').addEventListener('click', () => {
 document.getElementById('kortingscode').addEventListener('input', updateBedrag);
 extraInput.addEventListener('input', updateBedrag);
 
+function setSelectedKamer(type) {
+  const hidden = document.getElementById('kamer');
+  hidden.value = type;
+  document.querySelectorAll('.kamer-pill').forEach(pill => {
+    if (pill.textContent === type) pill.classList.add('active');
+    else pill.classList.remove('active');
+  });
+  updateBedrag();
+}
+
+function createKamerPills() {
+  const container = document.getElementById('kamerPills');
+  Object.keys(kamerPrijzen).forEach(type => {
+    const pill = document.createElement('button');
+    pill.type = 'button';
+    pill.className = 'kamer-pill';
+    pill.textContent = type;
+    pill.addEventListener('click', () => {
+      const current = document.getElementById('kamer').value;
+      if (current === type) {
+        setSelectedKamer('');
+        if (currentRes) currentRes.kamer = '';
+      } else {
+        setSelectedKamer(type);
+        if (currentRes) currentRes.kamer = type;
+      }
+    });
+    container.appendChild(pill);
+  });
+}
+
 window.addEventListener('DOMContentLoaded', () => {
   currentHotel = 'beach';
   document.body.classList.add(currentHotel);
@@ -65,6 +96,8 @@ window.addEventListener('DOMContentLoaded', () => {
   document.getElementById('employeeNameDisplay').textContent = medewerkerNaam || 'Naam medewerker';
   idPlaceholder.apply();
   ccPlaceholder.apply();
+  createKamerPills();
+  setSelectedKamer('');
 });
 
 document.getElementById('newResBtn').addEventListener('click', () => {
@@ -192,9 +225,8 @@ function openKamerSelectie() {
     const row = document.createElement('tr');
     row.innerHTML = `<td>${type}</td><td>${kamerPrijzen[type].beschrijving}</td><td>€ ${kamerPrijzen[type].prijs},-</td>`;
     row.addEventListener('click', () => {
-      document.getElementById('kamer').value = type;
+      setSelectedKamer(type);
       currentRes.kamer = type;
-      updateBedrag();
       document.getElementById('kamerSelectModal').classList.add('hidden');
     });
     table.appendChild(row);
@@ -339,7 +371,7 @@ function fillDetails(res) {
   document.getElementById('naam').value = res.naam;
   document.getElementById('gasten').value = res.gasten;
   document.getElementById('nachten').value = res.nachten;
-  document.getElementById('kamer').value = res.kamer;
+  setSelectedKamer(res.kamer);
   document.getElementById('etage').value = res.etage || '';
   document.getElementById('aankomst').value = res.aankomst || '';
   idInput.value = res.idNummer || '';
@@ -361,10 +393,10 @@ function updateBedrag() {
   const code = document.getElementById('kortingscode').value.trim();
   const discount = kortingsCodes[code] || 0;
   const bedrag = Math.max(0, base - discount);
-  document.getElementById('bedragDisplay').textContent = "Bedrag: € " + bedrag + ",-";
+  document.getElementById('bedragDisplay').innerHTML = "Bedrag:<br>€ " + bedrag + ",-";
   const extras = parseFloat(extraInput.value) || 0;
   const totaal = bedrag + extras;
-  document.getElementById('totaalDisplay').textContent = "Totaal: € " + totaal + ",-";
+  document.getElementById('totaalDisplay').innerHTML = "Totaal:<br>€ " + totaal + ",-";
   if (currentRes) {
     currentRes.extras = extras;
     currentRes.bedrag = bedrag;

--- a/index.html
+++ b/index.html
@@ -69,8 +69,9 @@
             <label>Aantal nachten:<br><input type="number" id="nachten" min="1" max="30"></label>
             <label>Kamernummer:<br><input type="text" id="kamerpas"></label>
             <label class="kamer-type">Type kamer:<br>
-              <input type="text" id="kamer" readonly>
-              <button type="button" id="selectKamerBtn"><span class="material-icons">search</span> Selecteren</button>
+              <input type="hidden" id="kamer">
+              <div id="kamerPills" class="kamer-pills"></div>
+              <button type="button" id="selectKamerBtn"><span class="material-icons">search</span> Meer info</button>
               <button type="button" id="upgradeBtn"><span class="material-icons">upgrade</span> Upgrade</button>
             </label>
             <label>Etage:<br><input type="number" id="etage" min="1" max="20"></label>

--- a/style.css
+++ b/style.css
@@ -1,10 +1,12 @@
 body { font-family: Arial, sans-serif; margin:0; padding:0; }
+table { width:100%; table-layout:fixed; }
+th, td { word-wrap:break-word; }
 header { display:flex; align-items:center; justify-content:space-between; padding:1em; color:white; }
 header img { height:50px; margin-right:1em; }
 .header-left { display:flex; align-items:center; }
 .header-right { display:flex; align-items:center; gap:1em; }
 .header-right button { width:auto; }
-#userInfo { display:flex; align-items:center; gap:0.3em; cursor:pointer; }
+#userInfo { display:flex; align-items:center; gap:0.3em; cursor:pointer; flex:0 0 150px; overflow:hidden; }
 .columns { display:flex; gap:1em; padding:1em; margin:0 5%; }
 .left-col { flex:0 0 33%; background:#f9f9f9; padding:1em; border-radius:4px; }
 .right-col { flex:0 0 67%; background:#f9f9f9; padding:1em; border-radius:4px; }
@@ -48,6 +50,7 @@ body.beach button:hover { background-color: #009e8a; }
   background: white;
   color: green;
   padding: 0;
+  flex:0 0 60px;
 }
 #newResBtn .material-icons {
   color: green;
@@ -143,7 +146,8 @@ input.placeholder-active {
 .hidden { display:none; }
 
 /* Bedrag kader */
-#bedragDisplay { background: #fffae6; padding: 0.5em; margin-top: 0.5em; border: 2px solid #ffd700; font-weight: bold; }
+#bedragDisplay, #totaalDisplay { background: #fffae6; padding: 0.5em; margin-top: 0.5em; border: 2px solid #ffd700; font-weight: bold; text-align:right; }
+#totaalDisplay { font-size:1.2em; }
 
 /* Randomizer buttons inline */
 label.with-rand input { width: calc(100% - 50px); display:inline-block; }
@@ -153,8 +157,14 @@ label.with-calc input { width: calc(100% - 50px); display:inline-block; }
 label.with-calc button { width:40px; margin-left:4px; display:inline-flex; }
 
 /* Kamer type buttons inline */
-label.kamer-type input { width: calc(100% - 110px); display:inline-block; }
+label.kamer-type .kamer-pills { display:flex; gap:0.5em; flex-wrap:wrap; margin-top:0.3em; }
 label.kamer-type button { width:auto; margin-left:4px; display:inline-flex; }
+label.kamer-type input { display:none; }
+.kamer-pill { border-radius:20px; padding:0.3em 0.8em; border:2px solid currentColor; background:white; color:inherit; cursor:pointer; }
+.kamer-pill.active { background:currentColor; color:white; }
+body.beach .kamer-pill { color:#00bfa5; }
+body.zonnestraal .kamer-pill { color:#ffcc00; }
+body.palace .kamer-pill { color:#d4af37; }
 
 /* Action buttons in one row */
 .buttons { display:flex; gap:0.5em; }


### PR DESCRIPTION
## Summary
- Replace room type text field with selectable pills and rename info button
- Stack price, extras, and total vertically with larger total amount
- Prevent header buttons from shifting and wrap table column content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68945dbddedc832c8e3a8eb4afd00445