### PR TITLE
Update room type pill styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -141,18 +141,18 @@ label.with-calc button { width:40px; margin-left:4px; display:inline-flex; }
 label.kamer-type .kamer-pills { display:flex; gap:0.5em; flex-wrap:wrap; margin-top:0.3em; }
 label.kamer-type button { width:auto; margin-left:4px; display:inline-flex; }
 label.kamer-type input { display:none; }
-.kamer-pill {
+.kamer-pills .kamer-pill {
   border-radius:20px;
   padding:0.3em 0.8em;
-  border:1px solid #999;
-  background:#f3f3f3;
-  color:#666;
+  border:1px solid #ccc;
+  background:#fff;
+  color:#ccc;
   cursor:pointer;
 }
-.kamer-pill.active {
-  background:#f3f3f3;
-  color:white;
-  border:1px solid #f3f3f3;
+.kamer-pills .kamer-pill.active {
+  background:#ccc;
+  color:#fff;
+  border:1px solid #ccc;
 }
 
 /* Action buttons in one row */


### PR DESCRIPTION
## Summary
- style room-type pill buttons with white background and #ccc text/border when unselected
- highlight selected room type with #ccc background and white text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894674bddc0832c8e78d77e0dbae06d